### PR TITLE
fix WebSocket Unsubscribe()

### DIFF
--- a/Source/Coinbase.Pro/WebSockets/CoinbaseProWebSocket.cs
+++ b/Source/Coinbase.Pro/WebSockets/CoinbaseProWebSocket.cs
@@ -132,7 +132,7 @@ namespace Coinbase.Pro.WebSockets
 
       public void Unsubscribe(Subscription subscription)
       {
-         subscription.ExtraJson.Add("type", JToken.FromObject(MessageType.Unsubscribe));
+         subscription.ExtraJson["type"] = JToken.FromObject(MessageType.Unsubscribe);
 
          var json = JsonConvert.SerializeObject(subscription);
 


### PR DESCRIPTION
- the ExtraJson already contains `type : subscribe`
- instead of adding another `type`, it should replace the `type` instead